### PR TITLE
Fix mismatched coupling matrix

### DIFF
--- a/Metastable_chimera_states.ipynb
+++ b/Metastable_chimera_states.ipynb
@@ -63,6 +63,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "snj8aY8U7N0P"
+      },
+      "outputs": [],
       "source": [
         "# Plotting\n",
         "\n",
@@ -96,12 +101,7 @@
         "    plt.xticks([])\n",
         "    plt.yticks([])\n",
         "  plt.show()"
-      ],
-      "metadata": {
-        "id": "snj8aY8U7N0P"
-      },
-      "execution_count": 9,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
@@ -118,10 +118,10 @@
         "  n_tot = n0 * n1  # total number of oscillators\n",
         "  K = np.zeros((n_tot, n_tot))\n",
         "  for i in range(n_tot):\n",
-        "    x1 = np.mod(np.ceil(i / n0) - 1, n1) + 1  # community number\n",
+        "    x1 = np.mod(np.floor_divide(i, n0), n1) + 1  # community number\n",
         "    for j in range(i + 1, n_tot):\n",
         "      if i != j:  # ignore diagonals\n",
-        "        y1 = np.mod(np.ceil(j / n0) - 1, n1) + 1  # community number\n",
+        "        y1 = np.mod(np.floor_divide(j, n0), n1) + 1  # community number\n",
         "        if x1 == y1:  # same community\n",
         "          p = d0 / n0\n",
         "          k = k0\n",
@@ -216,21 +216,35 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
       "source": [
-        "main()"
-      ],
+        "# visualise the coupling matrix\n",
+        "K = build_matrix(n0, n1, d0, d1, k0, k1)\n",
+        "\n",
+        "fig, ax = plt.subplots()\n",
+        "im = ax.imshow(K)\n",
+        "fig.colorbar(im)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OfMsFrUtcEyS"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "main()"
+      ]
     }
   ],
   "metadata": {
     "colab": {
+      "collapsed_sections": [],
       "name": "Metastable chimera states.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
In Metastable_chimera_states.ipyny, the `build_matrix()` function does not work in the correct way. Judging from the results, it will mistakenly count the first oscillator into the last community, which will cause each community to be misaligned in all subsequent statistics and visualizations.

In this pull request, I fixed this problem and provided a simple implementation of visualizing coupling matrix.